### PR TITLE
Fixed the PostgreSQL timestamp error by properly handling `null` valu…

### DIFF
--- a/server/database.js
+++ b/server/database.js
@@ -478,7 +478,12 @@ class Database {
         for (const [key, value] of Object.entries(updatedItem)) {
           if (key !== 'id' && key !== 'updated_at') {
             updateFields.push(`${key} = $${paramIndex}`);
-            values.push(typeof value === 'object' ? JSON.stringify(value) : value);
+            // Handle null values properly for PostgreSQL
+            if (value === null || value === 'null') {
+              values.push(null);
+            } else {
+              values.push(typeof value === 'object' ? JSON.stringify(value) : value);
+            }
             paramIndex++;
           }
         }


### PR DESCRIPTION
…es in [`database.js`](file:///private/var/folders/1t/jgd723zs7p13lh7smhnh_sc40000gn/T/vibe-kanban/vk-cee1-getting-th/server/database.js#L481-L487). The issue was that string `"null"` was being passed to PostgreSQL instead of actual `null` values for timestamp fields.